### PR TITLE
RPRO-2831

### DIFF
--- a/R5ProTestbed.xcodeproj/project.pbxproj
+++ b/R5ProTestbed.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4874D59F1C221B9500A98102 /* AdaptiveBitrateControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4874D59E1C221B9500A98102 /* AdaptiveBitrateControllerTest.swift */; };
 		4874D5A31C221CD000A98102 /* ALToastView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4874D5A21C221CD000A98102 /* ALToastView.m */; };
 		4874ECD01C483FDA002BDA6D /* SubscribeStreamImageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4874ECCF1C483FDA002BDA6D /* SubscribeStreamImageTest.swift */; };
+		48BB1D811CED140D00D915E5 /* SubscribeSetSizeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BB1D801CED140D00D915E5 /* SubscribeSetSizeTest.swift */; };
 		48BF80AE1C245AA7000E996E /* PublishOrientationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF80AD1C245AA7000E996E /* PublishOrientationTest.swift */; };
 		48BF80B11C245D29000E996E /* Info-100.png in Resources */ = {isa = PBXBuildFile; fileRef = 48BF80B01C245D29000E996E /* Info-100.png */; };
 		48BF80B31C246F6D000E996E /* SubscribeAspectRatioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF80B21C246F6D000E996E /* SubscribeAspectRatioTest.swift */; };
@@ -51,6 +52,7 @@
 		4874D5A11C221CD000A98102 /* ALToastView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ALToastView.h; sourceTree = "<group>"; };
 		4874D5A21C221CD000A98102 /* ALToastView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ALToastView.m; sourceTree = "<group>"; };
 		4874ECCF1C483FDA002BDA6D /* SubscribeStreamImageTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SubscribeStreamImageTest.swift; path = Tests/SubscribeStreamImage/SubscribeStreamImageTest.swift; sourceTree = "<group>"; };
+		48BB1D801CED140D00D915E5 /* SubscribeSetSizeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeSetSizeTest.swift; sourceTree = "<group>"; };
 		48BF80AD1C245AA7000E996E /* PublishOrientationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PublishOrientationTest.swift; path = Tests/PublishOrientation/PublishOrientationTest.swift; sourceTree = "<group>"; };
 		48BF80B01C245D29000E996E /* Info-100.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Info-100.png"; sourceTree = "<group>"; };
 		48BF80B21C246F6D000E996E /* SubscribeAspectRatioTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SubscribeAspectRatioTest.swift; path = Tests/SubscribeAspectRatio/SubscribeAspectRatioTest.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 		48DFEDC91C21BE0B0040B624 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				48BB1D801CED140D00D915E5 /* SubscribeSetSizeTest.swift */,
 				48DFEDD61C21C2540040B624 /* BaseTest.swift */,
 				48DFEDCC1C21BF0A0040B624 /* PublishTest.swift */,
 				4874D59E1C221B9500A98102 /* AdaptiveBitrateControllerTest.swift */,
@@ -264,6 +267,7 @@
 				48DFEDCD1C21BF0A0040B624 /* PublishTest.swift in Sources */,
 				923363E41CE4CFF1000442BF /* PublishRemoteCallTest.swift in Sources */,
 				4874D59D1C2216DB00A98102 /* SubscribeTest.swift in Sources */,
+				48BB1D811CED140D00D915E5 /* SubscribeSetSizeTest.swift in Sources */,
 				485345071C23528400D409F3 /* PublishStreamImageTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/R5ProTestbed/SubscribeSetSizeTest.swift
+++ b/R5ProTestbed/SubscribeSetSizeTest.swift
@@ -1,0 +1,70 @@
+//
+//  SubscribeAspectRatioTest.swift
+//  R5ProTestbed
+//
+//  Created by Andy Zupko on 12/18/15.
+//  Copyright © 2015 Infrared5. All rights reserved.
+//
+
+import UIKit
+import R5Streaming
+
+@objc(SubscribeSetSizeTest)
+class SubscribeSetSizeTest: BaseTest {
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        setupR5VideoViewController()
+        
+        let config = getConfig()
+        // Set up the connection and stream
+        let connection = R5Connection(config: config)
+        self.subscribeStream = R5Stream(connection: connection)
+        self.subscribeStream!.delegate = self
+        
+        currentView?.attachStream(subscribeStream)
+        
+        self.subscribeStream!.play(Testbed.getParameter("stream1") as! String)
+        
+        
+        let tap : UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: "handleSingleTap:")
+        
+        self.view.addGestureRecognizer(tap)
+        
+    }
+    
+    func setupR5VideoViewController() -> R5VideoViewController{
+        
+        let r5View : R5VideoViewController = getNewR5VideoViewController(self.view.frame);
+        self.addChildViewController(r5View);
+        
+               view.addSubview(r5View.view)
+        
+        r5View.showPreview(true)
+        
+        r5View.showDebugInfo(Testbed.getParameter("debug_view") as! Bool)
+        
+        currentView = r5View;
+
+        r5View.setFrame(CGRect(x: 100, y: 100, width: 200, height: 200));
+
+        return currentView!
+    }
+    
+    func handleSingleTap(recognizer : UITapGestureRecognizer) {
+        
+            currentView!.setFrame(CGRect(x: 100, y: 100, width: 200, height: 200));
+        
+    }
+    
+    override func viewDidLayoutSubviews() {
+        
+
+        if(currentView != nil){
+            
+           // currentView?.setFrame(view.frame);
+        }
+        
+    }
+
+}

--- a/R5ProTestbed/Tests/SubscribeSetSize/SubscribeSetSizeTest.swift
+++ b/R5ProTestbed/Tests/SubscribeSetSize/SubscribeSetSizeTest.swift
@@ -1,0 +1,70 @@
+//
+//  SubscribeAspectRatioTest.swift
+//  R5ProTestbed
+//
+//  Created by Andy Zupko on 12/18/15.
+//  Copyright © 2015 Infrared5. All rights reserved.
+//
+
+import UIKit
+import R5Streaming
+
+@objc(SubscribeSetSizeTest)
+class SubscribeSetSizeTest: BaseTest {
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        setupR5VideoViewController()
+        
+        let config = getConfig()
+        // Set up the connection and stream
+        let connection = R5Connection(config: config)
+        self.subscribeStream = R5Stream(connection: connection)
+        self.subscribeStream!.delegate = self
+        
+        currentView?.attachStream(subscribeStream)
+        
+        self.subscribeStream!.play(Testbed.getParameter("stream1") as! String)
+        
+        
+        let tap : UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: "handleSingleTap:")
+        
+        self.view.addGestureRecognizer(tap)
+        
+    }
+    
+    func setupR5VideoViewController() -> R5VideoViewController{
+        
+        let r5View : R5VideoViewController = getNewR5VideoViewController(self.view.frame);
+        self.addChildViewController(r5View);
+        
+               view.addSubview(r5View.view)
+        
+        r5View.showPreview(true)
+        
+        r5View.showDebugInfo(Testbed.getParameter("debug_view") as! Bool)
+        
+        currentView = r5View;
+
+        r5View.setFrame(CGRect(x: 100, y: 100, width: 200, height: 200));
+
+        return currentView!
+    }
+    
+    func handleSingleTap(recognizer : UITapGestureRecognizer) {
+        
+            currentView!.setFrame(CGRect(x: 100, y: 100, width: 200, height: 200));
+        
+    }
+    
+    override func viewDidLayoutSubviews() {
+        
+
+        if(currentView != nil){
+            
+           // currentView?.setFrame(view.frame);
+        }
+        
+    }
+
+}

--- a/R5ProTestbed/tests.plist
+++ b/R5ProTestbed/tests.plist
@@ -5,7 +5,7 @@
 	<key>GlobalProperties</key>
 	<dict>
 		<key>bitrate</key>
-		<integer>256</integer>
+		<integer>400</integer>
 		<key>host</key>
 		<string>0.0.0.0</string>
 		<key>buffer_time</key>
@@ -19,7 +19,7 @@
 		<key>context</key>
 		<string>live</string>
 		<key>camera_width</key>
-		<integer>320</integer>
+		<integer>426</integer>
 		<key>camera_height</key>
 		<string>240</string>
 		<key>debug_view</key>
@@ -48,35 +48,40 @@
 		<key>publish</key>
 		<dict>
 			<key>LocalProperties</key>
-			<dict>
-				<key>bitrate</key>
-				<integer>256</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Publish</string>
 			<key>class</key>
 			<string>PublishTest</string>
 		</dict>
-		<key>publish - 1200</key>
+		<key>publish - 1080p</key>
 		<dict>
 			<key>description</key>
-			<string>A high bitrate publisher</string>
+			<string>A high quality publisher</string>
 			<key>LocalProperties</key>
 			<dict>
+				<key>camera_width</key>
+				<integer>1920</integer>
+				<key>camera_height</key>
+				<string>1080</string>
 				<key>bitrate</key>
-				<integer>1200</integer>
+				<integer>4500</integer>
 			</dict>
 			<key>name</key>
-			<string>Publish - 1200</string>
+			<string>Publish - 1080p</string>
 			<key>class</key>
 			<string>PublishTest</string>
 		</dict>
 		<key>publish - ABR</key>
 		<dict>
 			<key>description</key>
-			<string>A high bitrate publisher with AdaptiveBitrateController</string>
+			<string>A high quality publisher with AdaptiveBitrateController</string>
 			<key>LocalProperties</key>
 			<dict>
+				<key>camera_width</key>
+				<integer>1920</integer>
+				<key>camera_height</key>
+				<string>1080</string>
 				<key>bitrate</key>
 				<integer>4800</integer>
 			</dict>
@@ -90,10 +95,7 @@
 			<key>description</key>
 			<string>Touch the screen to swap which camera is being used! Verify using flash that camera is swapping properly and no rendering problems occur.</string>
 			<key>LocalProperties</key>
-			<dict>
-				<key>bitrate</key>
-				<integer>256</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Publish - Camera Swap</string>
 			<key>class</key>
@@ -104,10 +106,7 @@
 			<key>description</key>
 			<string>Touch the publish stream to take a screen shot that is displayed!</string>
 			<key>LocalProperties</key>
-			<dict>
-				<key>bitrate</key>
-				<integer>256</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Publish - ImageCapture</string>
 			<key>class</key>
@@ -118,10 +117,7 @@
 			<key>description</key>
 			<string>Touch the screen to rotate the output video 90 degrees.  Verify with flash, android, or other iOS device running subscribe test.</string>
 			<key>LocalProperties</key>
-			<dict>
-				<key>bitrate</key>
-				<integer>256</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Publish - Orientation Change</string>
 			<key>class</key>
@@ -132,12 +128,9 @@
 			<key>description</key>
 			<string>A publish example that records stream data on the server.</string>
 			<key>LocalProperties</key>
-			<dict>
-				<key>bitrate</key>
-				<integer>256</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
-			<string>publish - Record</string>
+			<string>Publish - Record</string>
 			<key>class</key>
 			<string>RecordedTest</string>
 		</dict>
@@ -155,10 +148,7 @@
 		<key>subscribe</key>
 		<dict>
 			<key>LocalProperties</key>
-			<dict>
-				<key>buffer_time</key>
-				<integer>1</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Subscribe</string>
 			<key>class</key>
@@ -169,10 +159,7 @@
 			<key>description</key>
 			<string>Change the fill mode of the stream.  scale to fill, scale to fit, scale fill.  Aspect ratio should be maintained on first 2.</string>
 			<key>LocalProperties</key>
-			<dict>
-				<key>buffer_time</key>
-				<integer>1</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Subscribe - Aspect Ratio</string>
 			<key>class</key>
@@ -183,10 +170,7 @@
 			<key>description</key>
 			<string>Detect Insufficient and Sufficient BW flags.  Test on a poor network using a publisher that has high video quality. Video should become sporadic or stop altogether.  The screen will darken when no video is being received.</string>
 			<key>LocalProperties</key>
-			<dict>
-				<key>buffer_time</key>
-				<integer>1</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Subscribe - Bandwidth Test</string>
 			<key>class</key>
@@ -208,10 +192,7 @@
 			<key>description</key>
 			<string>Touch the subscribe stream to take a screen shot that is displayed!</string>
 			<key>LocalProperties</key>
-			<dict>
-				<key>bitrate</key>
-				<integer>1200</integer>
-			</dict>
+			<dict/>
 			<key>name</key>
 			<string>Subscribe - ImageCapture</string>
 			<key>class</key>

--- a/R5ProTestbed/tests.plist
+++ b/R5ProTestbed/tests.plist
@@ -31,6 +31,13 @@
 	</dict>
 	<key>Tests</key>
 	<dict>
+		<key>subscribe - SetFrame</key>
+		<dict>
+			<key>name</key>
+			<string>Subscribe - Set Frame Size</string>
+			<key>class</key>
+			<string>SubscribeSetSizeTest</string>
+		</dict>
 		<key>home</key>
 		<dict>
 			<key>class</key>

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Once you have modified your settings, you can run the application for simulator 
 
 ###[Publishing](R5ProTestbed/Tests/Publish)
 
-| **[1200](R5ProTestbed/Tests/Publish)**                 
+| **[1080p](R5ProTestbed/Tests/Publish)**                 
 | :-----
-| *A high bitrate publisher. Note that this is the publish test with a non-default 'bitrate' value set in tests.plist* 
+| *A high quality publisher. Note that this is the publish test with a non-default 'bitrate' and camera size values set in tests.plist* 
 |
 | **[ABR](R5ProTestbed/Tests/AdaptiveBitrate)**
 | *A high bitrate publisher with AdaptiveBitrateController*   


### PR DESCRIPTION
By default, tests use low resolution (426x240 @ 400kbps)
The only tests with local properties that override those are the tests that need high resolution (1920x1080 @ 4500kbps)
The 1200kbps publish example has been updated to be a high res example, and renamed 1080p
